### PR TITLE
Fix confirmation redirect url after the form submition for plain permalinks.

### DIFF
--- a/inc/admin/class-gf-paydock-create-customer-feed.php
+++ b/inc/admin/class-gf-paydock-create-customer-feed.php
@@ -130,13 +130,12 @@ class GF_Paydock_Create_Customer_Feed extends GFFeedAddOn {
 			if ( !empty( $confirmation['redirect'] ) ) {
 				$url = $confirmation['redirect'];
 				//base64_encode()
-				$url.= '?id='.urlencode( base64_encode( $entry['id'] ) );
+				$url.= (strpos($url, '?') !== false ?"&":"?") . 'id='.urlencode( base64_encode( $entry['id'] ) );
 				$url.= '&customerid='.urlencode( base64_encode( $customer_data['customer_id'] ) );
 				//$url.= '&customer='.urlencode( $customer_data['customer_id']);
 				$confirmation['redirect'] = $url;
 			}
 		}
-		// var_dump( $confirmation );die;
 		return $confirmation;
 	}
 


### PR DESCRIPTION
Fix confirmation redirect url after the form submition in case if permalinks structure is plain:

before:   site.url?page_id=35?id=...

after:    site.url?page_id=35&id=...

the double "?" caused the problem