### PR TITLE
Hide WYSIWYG Editor for the valid workflow.

### DIFF
--- a/css/paydock-admin.css
+++ b/css/paydock-admin.css
@@ -4,14 +4,3 @@
 #gaddon-setting-row-transaction_end_value{
 	display: none;
 }
-
-/* Hide WYSIWYG editor for the valid workflow */
-
-#config_token{
-    display:block !important;
-    visibility:visible !important
-}
-
-div#cke_config_token{
-    display:none !important
-}

--- a/css/paydock-admin.css
+++ b/css/paydock-admin.css
@@ -4,3 +4,14 @@
 #gaddon-setting-row-transaction_end_value{
 	display: none;
 }
+
+/* Hide WYSIWYG editor for the valid workflow */
+
+#config_token{
+    display:block !important;
+    visibility:visible !important
+}
+
+div#cke_config_token{
+    display:none !important
+}

--- a/inc/admin/class-gf-paydock-field-settings.php
+++ b/inc/admin/class-gf-paydock-field-settings.php
@@ -25,8 +25,6 @@ class GF_Paydock_Field_Settings {
 			</label>
 			<textarea  id="config_token" class="fieldwidth-3 fieldheight-1  mt-position-right mt-prepopulate" onkeyup="SetFieldProperty('config_token', this.value);"></textarea>
 			<p>Paste in configuration token here.</p>
-                        <!-- Hide WYSIWYG editor for the valid workflow -->
-                        <style>#config_token{display:block!important;visibility:visible!important}div#cke_config_token{display:none!important}</style>
 		</li>
 
 		<li class="paypal_gateway field_setting">

--- a/inc/admin/class-gf-paydock-field-settings.php
+++ b/inc/admin/class-gf-paydock-field-settings.php
@@ -25,6 +25,8 @@ class GF_Paydock_Field_Settings {
 			</label>
 			<textarea  id="config_token" class="fieldwidth-3 fieldheight-1  mt-position-right mt-prepopulate" onkeyup="SetFieldProperty('config_token', this.value);"></textarea>
 			<p>Paste in configuration token here.</p>
+                        <!-- Hide WYSIWYG editor for the valid workflow -->
+                        <style>#config_token{display:block!important;visibility:visible!important}div#cke_config_token{display:none!important}</style>
 		</li>
 
 		<li class="paypal_gateway field_setting">

--- a/inc/admin/class-gf-paydock-field-settings.php
+++ b/inc/admin/class-gf-paydock-field-settings.php
@@ -23,7 +23,7 @@ class GF_Paydock_Field_Settings {
 				<?php esc_html_e( 'Configuration Token', 'gfpaydock' ); ?>
 				<?php gform_tooltip( 'form_paydock_credit_card_config_token' ) ?>
 			</label>
-			<textarea  id="config_token" class="fieldwidth-3 fieldheight-1  mt-position-right mt-prepopulate" onkeyup="SetFieldProperty('config_token', this.value);"></textarea>
+			<textarea  id="config_token" class="fieldwidth-3 fieldheight-1  mt-position-right mt-prepopulate wysiwyg_exclude" onkeyup="SetFieldProperty('config_token', this.value);"></textarea>
 			<p>Paste in configuration token here.</p>
 		</li>
 


### PR DESCRIPTION
Remove conflict with the "CKEditor WYSIWYG for Gravity Forms" plugin.